### PR TITLE
Added semicolon to unbreak linter

### DIFF
--- a/src/flextree.js
+++ b/src/flextree.js
@@ -1,7 +1,7 @@
 import {hierarchy} from 'd3-hierarchy';
 import packageInfo from '../package.json';
 
-const {version} = packageInfo 
+const {version} = packageInfo; 
 const defaults = Object.freeze({
   children: data => data.children,
   nodeSize: node => node.data.size,


### PR DESCRIPTION
Added semicolon to unbreak linter:

#10 151.5 npm ERR! /root/.npm/_cacache/tmp/git-clone-9c5e3dba/src/flextree.js
#10 151.5 npm ERR! 4:30 error Missing semicolon semi
#10 151.5 npm ERR!
#10 151.5 npm ERR! /root/.npm/_cacache/tmp/git-clone-9c5e3dba/src/test/api-tests.js
#10 151.5 npm ERR! 5:30 error Missing semicolon semi
#10 151.5 npm ERR!
#10 151.5 npm ERR! ✖ 2 problems (2 errors, 0 warnings)